### PR TITLE
Utilisation d'await et async superflu

### DIFF
--- a/js/utils/weatherStackAPI.js
+++ b/js/utils/weatherStackAPI.js
@@ -10,9 +10,9 @@ const _retrieveWeatherForecastApiData = coordinates => fetch(`http://api.weather
     .catch(err => console.log("Oh no", err))
 
 
-const retrieveWeatherForecastData = async (coordinates, isMocked) => {
+const retrieveWeatherForecastData = (coordinates, isMocked) => {
     if (isMocked) {
-        return await _retrieveWeatherForecastMockedData()
+        return _retrieveWeatherForecastMockedData()
     }
-    return await _retrieveWeatherForecastApiData(coordinates)
+    return _retrieveWeatherForecastApiData(coordinates)
 }


### PR DESCRIPTION
Les méthodes `_retrieveWeatherForecastMockedData` et `_retrieveWeatherForecastApiData` retournent des promesses (utilisation de `fetch`). 
Une méthode asynchrone (`async`), renvoi aussi promesse.  
De ce fait, c'est inutile de l'utiliser sur `retrieveWeatherForecastData`, car on renverra dans tous les cas une promesse !